### PR TITLE
https://github.com/OpenPaaS-Suite/esn/issues/36 forces CI to fetch the newest packages when running 'npm install'

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
   stages {
     stage('Install packages') {
       steps {
-        sh 'npm install'
+        sh 'npm install -f'
       }
     }
 


### PR DESCRIPTION
Partially resolve https://github.com/OpenPaaS-Suite/esn/issues/36